### PR TITLE
no overlapping availabilities

### DIFF
--- a/lib/live_view_scheduler/interview_availability.ex
+++ b/lib/live_view_scheduler/interview_availability.ex
@@ -10,6 +10,7 @@ defmodule LiveViewScheduler.InterviewAvailability do
     field :deleted, :boolean
     field :temp_id, :string, virtual: true
     field :date, :date, virtual: true
+    field :overlaps, :boolean, virtual: true
 
     belongs_to :interview_stage, InterviewStage
 
@@ -24,7 +25,8 @@ defmodule LiveViewScheduler.InterviewAvailability do
       :interview_stage_id,
       :temp_id,
       :date,
-      :deleted
+      :deleted,
+      :overlaps
     ])
     |> validate_required(:start_datetime, message: "Start time must be selected")
     |> validate_required(:end_datetime, message: "End time must be selected")
@@ -33,6 +35,13 @@ defmodule LiveViewScheduler.InterviewAvailability do
     )
     |> validate_date_times()
     |> validate_cannot_delete_past_availability()
+    |> validate_no_overlap()
+  end
+
+  defp validate_no_overlap(changeset) do
+    if get_field(changeset, :overlaps) == true,
+      do: add_error(changeset, :overlaps, "Cannot overlap with other availabilities"),
+      else: changeset
   end
 
   defp validate_date_times(changeset = %{errors: []}) do

--- a/lib/live_view_scheduler/interview_availability.ex
+++ b/lib/live_view_scheduler/interview_availability.ex
@@ -38,12 +38,6 @@ defmodule LiveViewScheduler.InterviewAvailability do
     |> validate_no_overlap()
   end
 
-  defp validate_no_overlap(changeset) do
-    if get_field(changeset, :overlaps) == true,
-      do: add_error(changeset, :overlaps, "Cannot overlap with other availabilities"),
-      else: changeset
-  end
-
   defp validate_date_times(changeset = %{errors: []}) do
     start_datetime = get_change(changeset, :start_datetime)
     end_datetime = get_change(changeset, :end_datetime)
@@ -114,5 +108,11 @@ defmodule LiveViewScheduler.InterviewAvailability do
     else
       changeset
     end
+  end
+
+  defp validate_no_overlap(changeset) do
+    if get_field(changeset, :overlaps) == true,
+      do: add_error(changeset, :overlaps, "Cannot overlap with other availabilities"),
+      else: changeset
   end
 end

--- a/lib/live_view_scheduler/interview_stage.ex
+++ b/lib/live_view_scheduler/interview_stage.ex
@@ -14,6 +14,12 @@ defmodule LiveViewScheduler.InterviewStage do
     timestamps(type: :utc_datetime_usec)
   end
 
+  def create_changeset(%__MODULE__{} = interview_stage, attrs) do
+    interview_stage
+    |> cast(attrs, [:name, :duration])
+    |> validate_required([:name, :duration])
+  end
+
   def availability_changeset(
         %__MODULE__{interview_availabilities: interview_availabilities} = interview_stage,
         attrs

--- a/lib/live_view_scheduler/interview_stage.ex
+++ b/lib/live_view_scheduler/interview_stage.ex
@@ -11,6 +11,7 @@ defmodule LiveViewScheduler.InterviewStage do
       on_delete: :delete_all,
       on_replace: :mark_as_invalid
 
+
     timestamps(type: :utc_datetime_usec)
   end
 
@@ -25,6 +26,13 @@ defmodule LiveViewScheduler.InterviewStage do
         attrs
       )
       when is_list(interview_availabilities) do
+    # Feature4: Not be able to add overlapping interview availabilities for the same day
+    # We will go through all new interview_availabilities and
+    # add a virtual %{"overlaps": true} to those which overlap.
+    # `InterviewAvailability.create_changeset/2` will run `validate_no_overlap/1` to
+    # add error message.
+    attrs = prepare_interview_availability_attrs(attrs)
+
     interview_stage
     |> cast(attrs, [])
     |> cast_assoc(
@@ -35,4 +43,127 @@ defmodule LiveViewScheduler.InterviewStage do
       end
     )
   end
+
+  #
+  defp prepare_interview_availability_attrs(%{
+         "interview_availabilities" => attrs
+       }) do
+    marked_attrs =
+      attrs
+      |> Map.to_list()
+      |> Enum.map(&elem(&1, 1))
+      |> mark_overlaps()
+      # should test this to see if order holds.
+      |> Enum.with_index(fn slot, i -> {Integer.to_string(i), slot} end)
+      |> Map.new()
+
+    %{"interview_availabilities" => marked_attrs}
+  end
+
+  defp prepare_interview_availability_attrs(%{}), do: %{}
+  defp prepare_interview_availability_attrs(attrs), do: attrs
+
+  @doc """
+  Adds %{"overlap" => true} to mark an interview_availablility
+  attribute as overlapping with any other.
+  InterviewAvailability.create_changeset/2 will run validation and
+  add errors.
+  """
+  def mark_overlaps([]), do: []
+  def mark_overlaps(list), do: mark_overlaps(list, [])
+  def mark_overlaps([], acc), do: Enum.reverse(acc)
+
+  def mark_overlaps([slot | slots], acc) do
+    if slots
+       |> Enum.map(&overlaps?(slot, &1))
+       |> Enum.any?() do
+      # we need to mark each remaining slot if it overlaps with the current slot
+      slots =
+        slots
+        |> Enum.map(fn
+          %{"overlaps" => true} = val ->
+            val
+
+          val ->
+            if overlaps?(slot, val),
+              do: Map.put(val, "overlaps", true),
+              else: val
+        end)
+
+      mark_overlaps(slots, [Map.put(slot, "overlaps", true) | acc])
+    else
+      # we want every slot to be marked
+      if Map.get(slot, "overlaps"),
+        do: mark_overlaps(slots, [slot | acc]),
+        else: mark_overlaps(slots, [Map.put(slot, "overlaps", false) | acc])
+    end
+  end
+
+  # we only want to run final interval comparison if
+  # there are two valid sets of datetimes to compare
+  # this checks the first set
+  defp overlaps?(a, b) when is_map(a) do
+    if Map.get(a, "start_datetime") |> valid_datetime?() and
+         Map.get(a, "end_datetime") |> valid_datetime?(),
+       do: overlaps?({:ok, a}, b),
+       else: false
+  end
+
+  # this checks the second
+  defp overlaps?({:ok, a}, b) when is_map(b) do
+    if Map.get(b, "start_datetime") |> valid_datetime?() and
+         Map.get(b, "end_datetime") |> valid_datetime?(),
+       do: overlaps?({:ok, a}, {:ok, b}),
+       else: false
+  end
+
+  # this makes sure that we can build valid Intervals.
+  # For instance, when user has set same start/end datetimes
+  # Timex.Interval.new cannot handle 0 minute durations
+  # we want to mark these slots as %{"overlaps": false} and
+  # let changeset's validate_duration/4 to deal with this
+  defp overlaps?({:ok, a}, {:ok, b}) do
+    with %Timex.Interval{} = interval_a <- make_interval(a),
+         %Timex.Interval{} = interval_b <- make_interval(b),
+         do: Timex.Interval.overlaps?(interval_a, interval_b)
+  end
+
+  defp to_datetime(datetime) when is_binary(datetime) do
+    {:ok, date, _} = Elixir.DateTime.from_iso8601(datetime)
+    date
+  end
+
+  defp to_datetime(datetime), do: datetime
+
+  defp make_interval(slot) when is_map(slot) do
+    from =
+      slot
+      |> Map.get("start_datetime")
+      |> to_datetime()
+
+    to =
+      slot
+      |> Map.get("end_datetime")
+      |> to_datetime()
+
+    minutes = Timex.diff(from, to, :minutes)
+
+    case minutes do
+      # Timex.Interval.new cannot handle 0 minute intervals
+      0 ->
+        false
+
+      # happy case
+      minutes ->
+        Timex.Interval.new(
+          from: from,
+          until: [minutes: abs(minutes)]
+        )
+    end
+  end
+
+  defp valid_datetime?(""), do: false
+  defp valid_datetime?(nil), do: false
+  defp valid_datetime?(false), do: false
+  defp valid_datetime?(_), do: true
 end

--- a/lib/live_view_scheduler/interview_stages.ex
+++ b/lib/live_view_scheduler/interview_stages.ex
@@ -3,6 +3,12 @@ defmodule LiveViewScheduler.InterviewStages do
   alias LiveViewScheduler.Repo
   alias LiveViewScheduler.InterviewStage
 
+  def create_interview_stage(attrs \\ %{}) do
+    %InterviewStage{}
+    |> InterviewStage.create_changeset(attrs)
+    |> Repo.insert()
+  end
+
   def get_by_id!(id) do
     from(is in InterviewStage, where: is.id == ^id)
     |> Repo.one!()

--- a/lib/live_view_scheduler_web/interview_availability_live/form_components.ex
+++ b/lib/live_view_scheduler_web/interview_availability_live/form_components.ex
@@ -139,13 +139,16 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.FormComponents do
       )
 
     ~H"""
-    <div class="flex">
-      <.time_select id={@id} slot_form={@slot_form} field={:start_datetime} date={@date} />
-      <span class="m-8">-</span>
-      <.time_select id={@id} slot_form={@slot_form} field={:end_datetime} date={@date} />
-      <button type="button" phx-value-index={@slot_form.index} phx-click="delete-slot" class="m-8">
-        🗑
-      </button>
+    <div>
+      <div class="flex">
+        <.time_select id={@id} slot_form={@slot_form} field={:start_datetime} date={@date} />
+        <span class="m-8">-</span>
+        <.time_select id={@id} slot_form={@slot_form} field={:end_datetime} date={@date} />
+        <button type="button" phx-value-index={@slot_form.index} phx-click="delete-slot" class="m-8">
+          🗑
+        </button>
+      </div>
+        <%= error_tag(@slot_form, :overlaps) %>
     </div>
     """
   end

--- a/lib/live_view_scheduler_web/interview_availability_live/index.ex
+++ b/lib/live_view_scheduler_web/interview_availability_live/index.ex
@@ -100,14 +100,18 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.Index do
     # as we won't have the flash functionality in our test socket
     case save_interview_availabilities(socket, interview_stage) do
       {:error, changeset} ->
-        socket
-        |> put_flash(:error, "Error saving availability")
-        |> assign(changeset: changeset)
+        socket =
+          socket
+          |> put_flash(:error, "Error saving availability")
+          |> assign(changeset: changeset)
+
+        {:noreply, socket}
 
       socket ->
-        socket
-        |> clear_flash(:error)
-        |> put_flash(:info, "Availability saved")
+        socket =
+          socket
+          |> clear_flash(:error)
+          |> put_flash(:info, "Availability saved")
 
         {:noreply, socket}
     end

--- a/lib/live_view_scheduler_web/interview_availability_live/index.ex
+++ b/lib/live_view_scheduler_web/interview_availability_live/index.ex
@@ -7,22 +7,22 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.Index do
 
   def mount(%{"interview_stage_id" => interview_stage_id}, _session, socket) do
     selected_week_beginning = Timex.beginning_of_week(Date.utc_today())
-
-    interview_stage =
-      InterviewStages.get_weeks_availability_for_stage(
-        interview_stage_id,
-        selected_week_beginning
-      )
-
-    changeset = InterviewStage.availability_changeset(interview_stage, %{})
+    interview_stage = get_interview_stage(interview_stage_id, selected_week_beginning)
 
     socket =
       socket
-      |> assign(interview_stage: interview_stage)
-      |> assign(edit_mode: false)
-      |> assign(selected_week_beginning: selected_week_beginning)
-      |> assign(changeset: changeset)
+      |> assign_interview_stage(interview_stage)
+      |> assign_edit_mode(false)
+      |> assign_selected_week_beginning(selected_week_beginning)
+      |> assign_changeset()
 
+    {:ok, socket}
+  end
+
+  def mount(params, session, socket) do
+    IO.inspect(params, label: "#{__MODULE__} mounted params")
+    IO.inspect(session, label: "#{__MODULE__} mounted session")
+    IO.inspect(socket, label: "#{__MODULE__} mounted socket")
     {:ok, socket}
   end
 
@@ -54,38 +54,9 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.Index do
   def handle_event(
         "new-slot",
         %{"selected-day" => selected_day},
-        %{
-          assigns: %{
-            interview_stage: interview_stage,
-            changeset: changeset
-          }
-        } = socket
+        socket
       ) do
-    date = Date.from_iso8601!(selected_day)
-
-    existing_availability =
-      Changeset.get_change(
-        changeset,
-        :interview_availabilities,
-        Changeset.get_field(changeset, :interview_availabilities)
-      )
-
-    new_availability =
-      Ecto.build_assoc(interview_stage, :interview_availabilities, %{
-        temp_id: :crypto.strong_rand_bytes(5) |> Base.url_encode64() |> binary_part(0, 5),
-        date: date,
-        start_datetime: nil,
-        end_datetime: nil
-      })
-
-    changeset =
-      Changeset.put_assoc(
-        changeset,
-        :interview_availabilities,
-        existing_availability ++ [new_availability]
-      )
-
-    {:noreply, assign(socket, changeset: changeset)}
+    {:noreply, assign_new_slot_to_changeset(socket, selected_day)}
   end
 
   def handle_event("change-time", %{"interview_stage" => interview_stage}, socket) do
@@ -125,33 +96,27 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.Index do
   end
 
   def handle_event("save", %{"interview_stage" => interview_stage}, socket) do
-    socket =
-      InterviewStage.availability_changeset(socket.assigns.interview_stage, interview_stage)
-      |> Repo.update()
-      |> case do
-        {:ok, %InterviewStage{}} ->
-          updated_interview_stage =
-            InterviewStages.get_weeks_availability_for_stage(
-              socket.assigns.interview_stage.id,
-              socket.assigns.selected_week_beginning
-            )
+    # leave all flash-related stuff here for testing purposes
+    # as we won't have the flash functionality in our test socket
+    case save_interview_availabilities(socket, interview_stage) do
+      {:error, changeset} ->
+        socket
+        |> put_flash(:error, "Error saving availability")
+        |> assign(changeset: changeset)
 
-          socket
-          |> assign(edit_mode: false)
-          |> assign(:interview_stage, updated_interview_stage)
-          |> assign(
-            :changeset,
-            InterviewStage.availability_changeset(updated_interview_stage, %{})
-          )
-          |> clear_flash(:error)
-          |> put_flash(:info, "Availability saved")
+      socket ->
+        socket
+        |> clear_flash(:error)
+        |> put_flash(:info, "Availability saved")
 
-        {:error, changeset} ->
-          socket
-          |> put_flash(:error, "Error saving availability")
-          |> assign(changeset: changeset)
-      end
+        {:noreply, socket}
+    end
+  end
 
+  def handle_event(event, params, socket) do
+    IO.inspect(event, label: "#{__MODULE__} event")
+    IO.inspect(params, label: "#{__MODULE__} params")
+    IO.inspect(socket, label: "#{__MODULE__} socket")
     {:noreply, socket}
   end
 
@@ -179,4 +144,102 @@ defmodule LiveViewSchedulerWeb.InterviewAvailabilityLive.Index do
 
   defp availability_is_already_persisted?(%{temp_id: nil}), do: true
   defp availability_is_already_persisted?(_), do: false
+
+  @doc """
+  Extracted these as public functions for unit testing.
+  """
+  def get_interview_stage(interview_stage_id, selected_week_beginning) do
+    InterviewStages.get_weeks_availability_for_stage(
+      interview_stage_id,
+      selected_week_beginning
+    )
+  end
+
+  def assign_interview_stage(socket, interview_stage) do
+    assign(socket, :interview_stage, interview_stage)
+  end
+
+  def assign_edit_mode(socket, edit_mode) do
+    assign(socket, :edit_mode, edit_mode)
+  end
+
+  def assign_selected_week_beginning(socket, date) do
+    assign(socket, :selected_week_beginning, date)
+  end
+
+  def assign_changeset(%{assigns: %{interview_stage: interview_stage}} = socket) do
+    assign(socket, :changeset, InterviewStage.availability_changeset(interview_stage, %{}))
+  end
+
+  def assign_changeset(socket, changeset) do
+    assign(socket, :changeset, changeset)
+  end
+
+  def build_new_availability(%InterviewStage{} = interview_stage, date) do
+    Ecto.build_assoc(interview_stage, :interview_availabilities, %{
+      temp_id: :crypto.strong_rand_bytes(5) |> Base.url_encode64() |> binary_part(0, 5),
+      date: Date.from_iso8601!(date),
+      start_datetime: nil,
+      end_datetime: nil
+    })
+  end
+
+  def get_existing_availability(changeset) do
+    Changeset.get_change(
+      changeset,
+      :interview_availabilities,
+      Changeset.get_field(changeset, :interview_availabilities)
+    )
+  end
+
+  @spec update_interview_availabilities(Ecto.Changeset.t(), any) :: Ecto.Changeset.t()
+  def update_interview_availabilities(changeset, updated_availabilities) do
+    Changeset.put_assoc(
+      changeset,
+      :interview_availabilities,
+      updated_availabilities
+    )
+  end
+
+  def assign_new_slot_to_changeset(
+        %{
+          assigns: %{
+            interview_stage: interview_stage,
+            changeset: changeset
+          }
+        } = socket,
+        selected_day
+      ) do
+    new_availability = build_new_availability(interview_stage, selected_day)
+    existing_availability = get_existing_availability(changeset)
+
+    changeset =
+      update_interview_availabilities(changeset, existing_availability ++ [new_availability])
+
+    assign_changeset(socket, changeset)
+  end
+
+  def save_interview_availabilities(socket, interview_stage) do
+    InterviewStage.availability_changeset(socket.assigns.interview_stage, interview_stage)
+    |> Repo.update()
+    |> case do
+      {:ok, %InterviewStage{}} ->
+        updated_interview_stage =
+          InterviewStages.get_weeks_availability_for_stage(
+            socket.assigns.interview_stage.id,
+            socket.assigns.selected_week_beginning
+          )
+
+        socket
+        |> assign(edit_mode: false)
+        |> assign(:interview_stage, updated_interview_stage)
+        |> assign(
+          :changeset,
+          InterviewStage.availability_changeset(updated_interview_stage, %{})
+        )
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
 end

--- a/test/live_view_scheduler_web/interview_availability_live_test.exs
+++ b/test/live_view_scheduler_web/interview_availability_live_test.exs
@@ -1,0 +1,94 @@
+defmodule InterviewAvailabilityLiveTest do
+  use LiveViewSchedulerWeb.ConnCase
+  alias LiveViewScheduler.{InterviewStages, InterviewStage}
+  alias LiveViewSchedulerWeb.InterviewAvailabilityLive.Index, as: IA
+
+  def create_socket(_), do: %{socket: %Phoenix.LiveView.Socket{}}
+
+  @create_attrs %{
+    name: "test",
+    duration: 30
+  }
+
+  def assert_key(socket, key, value) do
+    assert socket.assigns[key] == value
+    socket
+  end
+
+  def create_interview_stage(_) do
+    {:ok, %InterviewStage{} = interview_stage} =
+      InterviewStages.create_interview_stage(@create_attrs)
+
+    [interview_stage: interview_stage]
+  end
+
+  def mount_socket(%{socket: socket, interview_stage: interview_stage}) do
+    selected_week_beginning = Timex.today()
+
+    interview_stage = IA.get_interview_stage(interview_stage.id, selected_week_beginning)
+
+    socket =
+      socket
+      |> IA.assign_interview_stage(interview_stage)
+      |> IA.assign_edit_mode(true)
+      |> IA.assign_selected_week_beginning(selected_week_beginning)
+      |> IA.assign_changeset()
+
+    [socket: socket]
+  end
+
+  defp extract_new_availability(socket) do
+    socket.assigns.changeset.changes.interview_availabilities
+    |> Enum.at(0)
+    |> Map.get(:data)
+  end
+
+  describe "unit tests with emulated Socket" do
+    setup [:create_socket, :create_interview_stage, :mount_socket]
+
+    test "adds a new empty slot", %{socket: socket} do
+      date = Timex.today()
+
+      assert socket.assigns.interview_stage.__meta__.state == :loaded
+      assert socket.assigns.interview_stage.interview_availabilities == []
+      assert socket.assigns.changeset.changes == %{}
+
+      socket = IA.assign_new_slot_to_changeset(socket, Date.to_iso8601(date))
+
+      # changes happened
+      refute socket.assigns.changeset.changes == %{}
+
+      # look at new_availability
+      new_availability = extract_new_availability(socket)
+
+      assert is_binary(new_availability.temp_id)
+    end
+
+    test "saves new interview availability", %{socket: socket} do
+      date = Timex.today()
+
+      socket = IA.assign_new_slot_to_changeset(socket, Date.to_iso8601(date))
+
+      new_availability = extract_new_availability(socket)
+
+      # emulate adding times to new slot
+      interview_availabilities = %{
+        "interview_availabilities" => %{
+          "0" => %{
+            "date" => date,
+            "end_datetime" => DateTime.new!(date, ~T[07:30:00.000000]),
+            "interview_stage_id" => Integer.to_string(new_availability.interview_stage_id),
+            "start_datetime" => DateTime.new!(date, ~T[07:00:00.000000]),
+            "temp_id" => new_availability.temp_id
+          }
+        }
+      }
+
+      # emulate submitting the form
+      socket = IA.save_interview_availabilities(socket, interview_availabilities)
+
+      # new interview availability has been persisted
+      refute socket.assigns.interview_stage.interview_availabilities == []
+    end
+  end
+end

--- a/test/live_view_scheduler_web/interview_availability_live_test.exs
+++ b/test/live_view_scheduler_web/interview_availability_live_test.exs
@@ -10,40 +10,6 @@ defmodule InterviewAvailabilityLiveTest do
     duration: 30
   }
 
-  def assert_key(socket, key, value) do
-    assert socket.assigns[key] == value
-    socket
-  end
-
-  def create_interview_stage(_) do
-    {:ok, %InterviewStage{} = interview_stage} =
-      InterviewStages.create_interview_stage(@create_attrs)
-
-    [interview_stage: interview_stage]
-  end
-
-  def mount_socket(%{socket: socket, interview_stage: interview_stage}) do
-    selected_week_beginning = Timex.today()
-
-    interview_stage = IA.get_interview_stage(interview_stage.id, selected_week_beginning)
-
-    socket =
-      socket
-      |> IA.assign_interview_stage(interview_stage)
-      |> IA.assign_edit_mode(true)
-      |> IA.assign_selected_week_beginning(selected_week_beginning)
-      |> IA.assign_changeset()
-
-    [socket: socket]
-  end
-
-  def assert_all(list, accessor_fn, predicate_fn) do
-    list
-    |> Enum.map(&accessor_fn.(&1))
-    |> Enum.map(&predicate_fn.(&1))
-    |> Enum.all?()
-  end
-
   describe "unit tests with emulated Socket" do
     setup [:create_socket, :create_interview_stage, :mount_socket]
 
@@ -118,26 +84,6 @@ defmodule InterviewAvailabilityLiveTest do
              |> assert_all(fn %{__meta__: meta} -> meta end, fn meta -> meta.state == :loaded end)
     end
 
-    def add_times_to_slots(
-          availabilities,
-          start_datetime \\ ~T[07:00:00.000000],
-          end_datetime \\ ~T[07:30:00.000000]
-        ) do
-      interview_availabilities =
-        for {%{data: data}, i} <- Enum.with_index(availabilities), into: Map.new() do
-          {Integer.to_string(i),
-           %{
-             "date" => data.date,
-             "end_datetime" => DateTime.new!(data.date, end_datetime),
-             "interview_stage_id" => Integer.to_string(data.interview_stage_id),
-             "start_datetime" => DateTime.new!(data.date, start_datetime),
-             "temp_id" => data.temp_id
-           }}
-        end
-
-      Map.put(%{}, "interview_availabilities", interview_availabilities)
-    end
-
     test "save several new interview availabilities for different non-past dates", %{
       socket: socket
     } do
@@ -201,4 +147,58 @@ defmodule InterviewAvailabilityLiveTest do
              ] = changes.interview_availabilities
     end
   end
+
+  defp assert_key(socket, key, value) do
+    assert socket.assigns[key] == value
+    socket
+  end
+
+  defp create_interview_stage(_) do
+    {:ok, %InterviewStage{} = interview_stage} =
+      InterviewStages.create_interview_stage(@create_attrs)
+
+    [interview_stage: interview_stage]
+  end
+
+  defp mount_socket(%{socket: socket, interview_stage: interview_stage}) do
+    selected_week_beginning = Timex.today()
+
+    interview_stage = IA.get_interview_stage(interview_stage.id, selected_week_beginning)
+
+    socket =
+      socket
+      |> IA.assign_interview_stage(interview_stage)
+      |> IA.assign_edit_mode(true)
+      |> IA.assign_selected_week_beginning(selected_week_beginning)
+      |> IA.assign_changeset()
+
+    [socket: socket]
+  end
+
+  defp assert_all(list, accessor_fn, predicate_fn) do
+    list
+    |> Enum.map(&accessor_fn.(&1))
+    |> Enum.map(&predicate_fn.(&1))
+    |> Enum.all?()
+  end
+
+  defp add_times_to_slots(
+          availabilities,
+          start_datetime \\ ~T[07:00:00.000000],
+          end_datetime \\ ~T[07:30:00.000000]
+        ) do
+      interview_availabilities =
+        for {%{data: data}, i} <- Enum.with_index(availabilities), into: Map.new() do
+          {Integer.to_string(i),
+           %{
+             "date" => data.date,
+             "end_datetime" => DateTime.new!(data.date, end_datetime),
+             "interview_stage_id" => Integer.to_string(data.interview_stage_id),
+             "start_datetime" => DateTime.new!(data.date, start_datetime),
+             "temp_id" => data.temp_id
+           }}
+        end
+
+      Map.put(%{}, "interview_availabilities", interview_availabilities)
+    end
 end

--- a/test/live_view_scheduler_web/mark_overlaps_test.exs
+++ b/test/live_view_scheduler_web/mark_overlaps_test.exs
@@ -1,0 +1,175 @@
+defmodule LiveViewSchedulerWeb.NoOverlapTest do
+  use LiveViewSchedulerWeb.ConnCase
+
+  @no_overlaps [
+    %{
+      "id" => "0",
+      "start_datetime" => "2023-08-28 07:45:00.000000Z",
+      "end_datetime" => "2023-08-28 09:00:00.000000Z"
+    },
+    %{
+      "id" => "1",
+      "start_datetime" => "2023-08-28 10:00:00.000000Z",
+      "end_datetime" => "2023-08-28 11:00:00.000000Z"
+    }
+  ]
+
+  @all_but_one_overlaps [
+    %{
+      "id" => "0",
+      "start_datetime" => "2023-08-28 07:15:00.000000Z",
+      "end_datetime" => "2023-08-28 07:45:00.000000Z"
+    },
+    %{
+      "id" => "1",
+      "start_datetime" => "2023-08-28 07:15:00.000000Z",
+      "end_datetime" => "2023-08-28 08:00:00.000000Z"
+    },
+    %{
+      "id" => "2",
+      "start_datetime" => "2023-08-28 07:45:00.000000Z",
+      "end_datetime" => "2023-08-28 09:00:00.000000Z"
+    },
+    # ok
+    %{
+      "id" => "3",
+      "start_datetime" => "2023-08-28 10:00:00.000000Z",
+      "end_datetime" => "2023-08-28 11:00:00.000000Z"
+    },
+    %{
+      "id" => "4",
+      "start_datetime" => "2023-08-30 07:30:00.000000Z",
+      "end_datetime" => "2023-08-30 09:30:00.000000Z"
+    },
+    %{
+      "id" => "5",
+      "start_datetime" => "2023-08-30 09:00:00.000000Z",
+      "end_datetime" => "2023-08-30 09:15:00.000000Z"
+    }
+  ]
+  @all_overlap [
+    %{
+      "id" => "0",
+      "start_datetime" => "2023-09-25 07:00:00.000000Z",
+      "end_datetime" => "2023-09-25 07:30:00.000000Z"
+    },
+    %{
+      "id" => "1",
+      "start_datetime" => "2023-09-25 07:00:00.000000Z",
+      "end_datetime" => "2023-09-25 07:30:00.000000Z"
+    },
+    %{
+      "id" => "2",
+      "start_datetime" => "2023-09-26 07:45:00.000000Z",
+      "end_datetime" => "2023-09-26 08:30:00.000000Z"
+    },
+    %{
+      "id" => "3",
+      "start_datetime" => "2023-09-26 08:00:00.000000Z",
+      "end_datetime" => "2023-09-26 09:00:00.000000Z"
+    }
+  ]
+  @with_incomplete_datetimes [
+    %{
+      "date" => "2023-09-04",
+      "end_datetime" => "2023-09-04 07:45:00.000000Z",
+      "id" => "0",
+      "interview_stage_id" => "2",
+      "start_datetime" => "2023-09-04 07:00:00.000000Z",
+      "temp_id" => ""
+    },
+    %{
+      "date" => "2023-09-04",
+      "end_datetime" => "2023-09-04 07:30:00.000000Z",
+      "id" => "1",
+      "interview_stage_id" => "2",
+      "start_datetime" => "2023-09-04 07:00:00.000000Z",
+      "temp_id" => ""
+    },
+    %{
+      "date" => "2023-09-05",
+      "end_datetime" => "",
+      "interview_stage_id" => "2",
+      "start_datetime" => "",
+      "temp_id" => "vVlgm",
+      "id" => "2"
+    }
+  ]
+  @with_same_datetimes [
+    %{
+      "date" => "2023-09-05",
+      "end_datetime" => "2023-09-04 07:30:00.000000Z",
+      "interview_stage_id" => "2",
+      "start_datetime" => "2023-09-04 07:30:00.000000Z",
+      "temp_id" => "vVlgm",
+      "id" => "0"
+    },
+    %{
+      "date" => "2023-09-05",
+      "end_datetime" => "2023-09-04 07:30:00.000000Z",
+      "interview_stage_id" => "2",
+      "start_datetime" => "2023-09-04 07:30:00.000000Z",
+      "temp_id" => "vVlgm",
+      "id" => "1"
+    }
+  ]
+
+  defp extract_results(list) do
+    Enum.map(list, &{Map.get(&1, "id"), Map.get(&1, "overlaps")})
+  end
+
+  describe "mark_overlaps" do
+    test "no overlaps" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(@no_overlaps)
+             |> extract_results() == [
+               {"0", false},
+               {"1", false}
+             ]
+    end
+
+    test "all but one overlap" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(@all_but_one_overlaps)
+             |> extract_results() == [
+               {"0", true},
+               {"1", true},
+               {"2", true},
+               {"3", false},
+               {"4", true},
+               {"5", true}
+             ]
+    end
+
+    test "all overlap" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(@all_overlap)
+             |> extract_results() == [
+               {"0", true},
+               {"1", true},
+               {"2", true},
+               {"3", true}
+             ]
+    end
+
+    test "with incomplete datetimes" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(@with_incomplete_datetimes)
+             |> extract_results() ==
+               [
+                 {"0", true},
+                 {"1", true},
+                 {"2", false}
+               ]
+    end
+
+    test "with same datetimes" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(@with_same_datetimes)
+             |> extract_results() == [
+               {"0", false},
+               {"1", false}
+             ]
+    end
+
+    test "with same datetime" do
+      assert LiveViewScheduler.InterviewStage.mark_overlaps(Enum.take(@with_same_datetimes, 1))
+             |> extract_results() == [{"0", false}]
+    end
+  end
+end


### PR DESCRIPTION
Implemented a required feature:

> Not be able to add overlapping interview availabilities for the same day.

**PROBLEM:** 
When users add new interview availability time slots they might accidentally add overlapping
times which would not be usable for booking purposes.  

**SOLUTION:**
1. Add `prepare_interview_availability_attrs/1` helper on `InterviewStage.availability_changeset/2` level that looks at all proposed interview availabilities and marks them as %{overlaps: boolean}. 
2. Add `validate_no_overlaps/1` to `InterviewAvailability.create_changeset/2` to correctly invalidate overlapping changeset and add error. 
3. Test